### PR TITLE
Enable URL checking.

### DIFF
--- a/config_automation.yml
+++ b/config_automation.yml
@@ -3,7 +3,7 @@
 # Check quiz formatting
 check-quizzes: no
 # Check that urls in the content are not broken
-url-checker: no
+url-checker: yes
 # Render preview of content with changes (Rmd's and md's are checked)
 render-preview: yes
 # Spell check Rmds and quizzes


### PR DESCRIPTION
Now that jhudsl/ottr-reports#24 is merged, we should be able to turn this on without having it attempt to download the FASTQ tarballs each time.